### PR TITLE
Brainfuck interpreter

### DIFF
--- a/commands/util/fuck.js
+++ b/commands/util/fuck.js
@@ -20,8 +20,8 @@ module.exports = class FuckCommand extends commando.Command {
       ]
     });
   }
-
-  async run(msg, { code }) {
+  
+  run(msg, { code }) {
     var arr = new Array(50000).fill(0);;
     var ptr = 0;
     var out = "brainfuck> ";


### PR DESCRIPTION
A simple brainfuck interpreter. Currently it supports everything except for user input (still needs to be tested).

Example use case:
`trt fuck ++>+++[->+<]++++++++[<++++++>-]<.`
This does 2+3 and prints out the answer.