### PR TITLE
Require whitespace in stocks regex

### DIFF
--- a/listeners/stockListener.js
+++ b/listeners/stockListener.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const oneLine = require('common-tags').oneLine;
-const symbolRegex = /(\$[A-Z]{1,4})($|\W)/gi;
+const symbolRegex = /((^)|(\s+))(\$[A-Z]{1,4})($|\W)/gi;
 const StocksClient = require('../actions/stocks.js');
 
 module.exports = async message => {


### PR DESCRIPTION
So messages like  "ke$ha" do not match the regex.